### PR TITLE
Add weekly digest function

### DIFF
--- a/app/inngest/client.ts
+++ b/app/inngest/client.ts
@@ -1,0 +1,8 @@
+import { EventSchemas, Inngest } from 'inngest'
+
+import { type Events } from './events'
+
+export const inngest = new Inngest({
+  id: 'my-app',
+  schemas: new EventSchemas().fromRecord<Events>()
+})

--- a/app/inngest/events.ts
+++ b/app/inngest/events.ts
@@ -1,0 +1,10 @@
+type NoteCreated = {
+  data: {
+    title: string;
+    image_url: string | null;
+  };
+};
+
+export type Events = {
+  'note.created': NoteCreated;
+};

--- a/app/inngest/functions/sendWeeklyDigest.tsx
+++ b/app/inngest/functions/sendWeeklyDigest.tsx
@@ -1,0 +1,63 @@
+import * as E from '@react-email/components'
+import { prisma } from '#app/utils/db.server.ts'
+import { sendEmail } from '#app/utils/email.server.ts'
+import { inngest } from '../client'
+
+export const sendWeeklyDigest = inngest.createFunction(
+	{ id: 'send-weekly-digest' },
+	{
+		cron: 'TZ=America/New_York 0 8 * * 1',
+	},
+	async ({ step }) => {
+		const users = await step.run('get-all-users', async () => {
+			return prisma.user.findMany()
+		})
+
+		for (const user of users) {
+			const digestData = await step.run('fetch-digest-data', async () => {
+				return {
+					notesCount: await prisma.note.count({
+						where: {
+							ownerId: user.id,
+						},
+					}),
+				}
+			})
+			await step.run(`send-digest`, async () => {
+				await sendEmail({
+					to: user.email,
+					subject: 'Epic Notes Weekly Digest',
+					react: <WeeklyDigestEmail digestData={digestData} />,
+				})
+			})
+		}
+
+		return {
+			result: `Sent ${users.length} weekly reports`,
+		}
+	},
+)
+
+function WeeklyDigestEmail({
+	digestData,
+}: {
+	digestData: {
+		notesCount: number
+	}
+}) {
+	return (
+		<E.Html lang="en" dir="ltr">
+			<E.Container>
+				<h1>
+					<E.Text>Your Epic notes weekly digest</E.Text>
+				</h1>
+				<p>
+					<E.Text>
+						You created {digestData.notesCount} notes this week. Great job, keep
+						it up!
+					</E.Text>
+				</p>
+			</E.Container>
+		</E.Html>
+	)
+}

--- a/app/inngest/index.ts
+++ b/app/inngest/index.ts
@@ -1,0 +1,6 @@
+import { sendWeeklyDigest } from './functions/sendWeeklyDigest'
+
+export { inngest } from './client'
+export const functions = [
+  sendWeeklyDigest,
+]

--- a/app/routes/resources+/inngest.ts
+++ b/app/routes/resources+/inngest.ts
@@ -1,33 +1,7 @@
-import { EventSchemas, Inngest } from 'inngest'
+import { inngest, functions } from '#app/inngest'
 import { serve } from 'inngest/remix'
 
-// Define the event type
-type HelloWorldEvent = {
-	name: 'test/hello.world'
-	data: {
-		name: string
-	}
-}
-
-// Create the schema
-export const schemas = new EventSchemas().fromUnion<HelloWorldEvent>()
-
-// Initialize the Inngest client with the schema
-const inngest = new Inngest({ id: 'my-app', schemas })
-
-// Define your functions here
-const helloWorld = inngest.createFunction(
-	{ id: 'hello-world', name: 'Hello World' },
-	{ event: 'test/hello.world' },
-	async ({ event, step }) => {
-		await step.run('Say hello', () => {
-			console.log(`Hello, ${event.data.name}!`)
-		})
-		return { message: `Hello, ${event.data.name}!` }
-	},
-)
-
 // Create the serve handler
-const inngestHandler = serve({ client: inngest, functions: [helloWorld] })
+const inngestHandler = serve({ client: inngest, functions })
 
 export { inngestHandler as action, inngestHandler as loader }


### PR DESCRIPTION
This extends the initial Inngest implementation by adding a weekly digest function for the Notes app. This first function is meant to show how to run something asynchronously using Inngest. A cron is the most basic example.

### Improvements
I was tempted to extend this with additional best practices, but held off prior to getting Kent's thoughts. If this were production-grade the cron function would use `step.invoke()` or `step.sendEvent()` to fan-out the actual email sending to another function. This would two functions each with a single responsibility: 
1. a cron function to load all users that have a digest enabled and 
2. a function that fetches the digest data for each user in the database then formats the email and sends it.

The benefits of that approach is that the second function can then use flow control, such as `throttle` to match Resend (or whatever provider's) API rate limit. Resend, by default limits to 2 requests per second, so sending a digest to many users so quickly may easily result in an 429 response from Resend's API. In the demo this isn't bad since emails aren't actually being sent, and just being printed to stdout, but in production, you would 100% want to add throttling.

## Test Plan

Start up the server as typical with `npm run dev` then in another terminal, run the Inngest dev server pointing to the route:

```
npx inngest-cli@latest dev -u http://localhost:3000/resources/inngest --no-discovery
```
Note - `--no-discovery` disables Inngest app port and path scanning that is helpful when originally getting started with Inngest.

### Notes

* Best practices: Typically, we recommend that any Inngest route be served at `/api/inngest`, 
* DX: I would add the `npx inngest-cli dev` command as an `npm run` script and potentially run this concurrently. This could also be achieved by wrapping the CLI and executing it via child process in `dev-server.js`


## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

Function available in the Inngest dashboard:
![image](https://github.com/user-attachments/assets/5d9c28fd-ee04-43be-b09f-65694a825b0f)

Test run of the function using local data:
![image](https://github.com/user-attachments/assets/d052da88-e557-4ead-9435-fe3f25fbfd85)
